### PR TITLE
fix pagination error

### DIFF
--- a/src/views/RepoPage/RepoPage.vue
+++ b/src/views/RepoPage/RepoPage.vue
@@ -125,7 +125,7 @@ export default {
   methods: {
     onPagination(val) {
       this.pageSize = val.length;
-      this.pageStart = val.start;
+      this.pageStart = Math.max(0, val.start - 1); // page numbers start at 1 - use max value as a precaution.
       this.page = val.page;
     }
   }


### PR DESCRIPTION
The page numbers start at 1 not 0 so the first repo is not shown. The easiest way to see this is by going to the last page.
![image](https://user-images.githubusercontent.com/7536103/93633393-eb980d80-f9bc-11ea-8713-fc4fa788653a.png)

There should be 6 items but there are only 5. The issue is that the first repo in the list is missing from page 1.

With the fix:
![image](https://user-images.githubusercontent.com/7536103/93633494-11251700-f9bd-11ea-8d21-f68d22c8a409.png)
